### PR TITLE
Fix off-by-one in app group identifier length check for POSIX semaphore prefix

### DIFF
--- a/Source/ios-framework/CommonSource/Store.swift
+++ b/Source/ios-framework/CommonSource/Store.swift
@@ -260,8 +260,9 @@ public class Store: CustomDebugStringConvertible {
 
                 // Semaphore names in macOS are limited to 31 characters.
                 // Internally, we need up to 11 chars to identify the semaphore,
-                // thus the group ID must be equal or less than 20 (ASCII) charaters.
-                if let appGroupIdentifier = applicationGroups.first(where: { $0.length <= 20 }) {
+                // thus the prefix (group ID + "/") must be at most 20 characters,
+                // meaning the group ID itself must be at most 19 characters.
+                if let appGroupIdentifier = applicationGroups.first(where: { $0.length <= 19 }) {
                     obx_posix_sem_prefix_set(appGroupIdentifier.appending("/"))
                     // print("found appGroupIdentifier \(appGroupIdentifier)")
                 } else {

--- a/Source/ios-framework/CommonSource/Store.swift
+++ b/Source/ios-framework/CommonSource/Store.swift
@@ -258,15 +258,11 @@ public class Store: CustomDebugStringConvertible {
                let entitlements = signingInfo[kSecCodeInfoEntitlementsDict] as? [NSString: NSObject],
                let applicationGroups = entitlements["com.apple.security.application-groups"] as? [NSString] {
 
-                // Semaphore names in macOS are limited to 31 characters.
-                // Internally, we need up to 11 chars to identify the semaphore,
-                // thus the prefix (group ID + "/") must be at most 20 characters,
-                // meaning the group ID itself must be at most 19 characters.
-                if let appGroupIdentifier = applicationGroups.first(where: { $0.length <= 19 }) {
-                    obx_posix_sem_prefix_set(appGroupIdentifier.appending("/"))
-                    // print("found appGroupIdentifier \(appGroupIdentifier)")
+                if let prefix = Store.semaphorePrefix(from: applicationGroups.map { $0 as String }) {
+                    obx_posix_sem_prefix_set(prefix)
+                    // print("found appGroupIdentifier \(prefix)")
                 } else {
-                    print("Could not find an application group identifier of 20 characters or fewer.")
+                    print("Could not find an application group identifier that fits within the 20-character prefix limit.")
                 }
             } else if err3 != noErr { // noErr means app has no entitlements, likely not sandboxed.
                 print("Error reading entitlements: \(err3)")
@@ -375,5 +371,20 @@ public class Store: CustomDebugStringConvertible {
         try obx_runInTransaction(writable: false, { _ in
             try block()
         })
+    }
+
+    // MARK: - POSIX Semaphore Prefix
+
+    /// Finds the first application group identifier that fits within the POSIX semaphore name budget.
+    ///
+    /// Semaphore names in macOS are limited to 31 characters. Internally, ObjectBox needs up to 11 characters
+    /// to identify the semaphore, so the prefix (group ID + "/") must be at most 20 characters.
+    ///
+    /// The trailing "/" is appended if not already present before checking the length, matching the behavior
+    /// of the Dart API.
+    static func semaphorePrefix(from applicationGroups: [String]) -> String? {
+        return applicationGroups.lazy
+            .map { $0.hasSuffix("/") ? $0 : $0.appending("/") }
+            .first(where: { $0.count <= 20 })
     }
 }

--- a/Source/ios-framework/CommonTests/StoreTests.swift
+++ b/Source/ios-framework/CommonTests/StoreTests.swift
@@ -346,4 +346,15 @@ class StoreTests: XCTestCase {
     func testClone() throws {
         try testAttachOrClone(clone: true)
     }
+
+    // MARK: - Semaphore Prefix
+
+    func testSemaphorePrefix() {
+        // Appends "/" and checks total length <= 20
+        XCTAssertEqual(Store.semaphorePrefix(from: ["ABCDEFGHIJ.12345678"]), "ABCDEFGHIJ.12345678/") // 19 + "/" = 20, OK
+        XCTAssertNil(Store.semaphorePrefix(from: ["ABCDEFGHIJ.123456789"])) // 20 + "/" = 21, too long
+        XCTAssertEqual(Store.semaphorePrefix(from: ["ABCDEFGHIJ.1234567/"]), "ABCDEFGHIJ.1234567/") // already has "/", no double slash
+        XCTAssertEqual(Store.semaphorePrefix(from: ["ABCDEFGHIJ.123456789", "SHORT.id"]), "SHORT.id/") // skips first, picks second
+        XCTAssertNil(Store.semaphorePrefix(from: [])) // empty
+    }
 }


### PR DESCRIPTION
## Summary

On sandboxed macOS, `Store.init` reads the app's entitlements and picks the first
application group identifier that fits within the POSIX semaphore name budget.
The current filter checks `$0.length <= 20` before appending "/", but
`obx_posix_sem_prefix_set` requires the total prefix (including "/") to be at most
20 characters. A group ID of exactly 20 characters passes the filter, becomes 21
after appending, and is rejected by the C library.

The rejected call sets thread-local error state, and because the return value of
`obx_posix_sem_prefix_set` is not checked, this stale error propagates into
`Store.init` via `checkLastError()`, causing initialization to fail with
`illegalArgument("Given prefix must not exceed 20 chars")`.

This was discovered in a production app whose shortest app group identifier is
exactly 20 characters (team ID + "." + 9-char name).

## Changes

- Changed the length filter from `<= 20` to `<= 19` to account for the appended "/"
- Updated the comment to clarify that the limit applies to the full prefix including "/"

## Testing

This is not covered by a unit test because `setUpMutexIdentifier` reads entitlements
from the running binary's code signature at runtime, which cannot be controlled in a
test environment. The fix is verified by code inspection.
